### PR TITLE
plural B9 descriptions

### DIFF
--- a/GameData/NearFutureExploration/Localization/en-us.cfg
+++ b/GameData/NearFutureExploration/Localization/en-us.cfg
@@ -9,6 +9,7 @@ Localization
     /// -----------
     // Structure
     #LOC_NFEX_Switcher_Structure = Structure
+    #LOC_NFEX_Switcher_StructurePlural = Structure Options
 
     #LOC_NFEX_Switcher_Structure_Basic = Basic
     #LOC_NFEX_Switcher_Structure_Basic_summary = Basic tank configuration
@@ -24,6 +25,7 @@ Localization
 
     // Surface
     #LOC_NFEX_Switcher_Surface_Bus = Surface
+    #LOC_NFEX_Switcher_Surface_Bus_Plural = Surface Options
 
     #LOC_NFEX_Switcher_Surface_Bus_Solid = Bare
     #LOC_NFEX_Switcher_Surface_Bus_Solid_summary = Basic metal
@@ -46,6 +48,7 @@ Localization
     
     // Endcaps
     #LOC_NFEX_Switcher_Endcap_Bus = Endcap
+    #LOC_NFEX_Switcher_Endcap_Bus_Plural = Endcap Options
 
     #LOC_NFEX_Switcher_Endcap_Bus_Solid = Bare
     #LOC_NFEX_Switcher_Endcap_Bus_Solid_summary = Basic metal
@@ -62,6 +65,7 @@ Localization
 
     // Fuel contents
     #LOC_NFEX_Switcher_FuelTank = Contents
+    #LOC_NFEX_Switcher_FuelTankPlural = Content Options
 
     #LOC_NFEX_Switcher_FuelTank_Metal = LFO 
     #LOC_NFEX_Switcher_FuelTank_Metal_summary = LiquidFuel/Oxidizer
@@ -87,6 +91,7 @@ Localization
 
     // Suspension
     #LOC_NFEX_Switcher_Suspension = Suspension
+    #LOC_NFEX_Switcher_Suspension_Plural = Suspension Modes
     #LOC_NFEX_Switcher_Suspension_On = Enabled
     #LOC_NFEX_Switcher_Suspension_On_summary = Enable suspension
     #LOC_NFEX_Switcher_Suspension_On_detail = Leg will have a fully configured suspension

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-adtp-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-adtp-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-adtp-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-adtp-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-chfr-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-chfr-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-chfr-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-chfr-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-cyl-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-cyl-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-cyl-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-cyl-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-dsk-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-dsk-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-dsk-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-dsk-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs-1.cfg
@@ -46,6 +46,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -94,6 +95,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs-2.cfg
@@ -46,6 +46,7 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -94,7 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
-    moduleID = endSwitch
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs2-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs2-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs2-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-hecs2-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+    switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-okto-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-okto-1.cfg
@@ -45,6 +45,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
+		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -93,7 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
-    moduleID = endSwitch
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-okto-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-okto-2.cfg
@@ -45,6 +45,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
+		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -93,7 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
-    moduleID = endSwitch
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-plto-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-plto-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-plto-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-plto-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-qbe-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-qbe-1.cfg
@@ -46,6 +46,7 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -94,7 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
-    moduleID = endSwitch
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-qbe-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-qbe-2.cfg
@@ -46,6 +46,7 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -94,7 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
-    moduleID = endSwitch
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rekt-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rekt-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rekt-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rekt-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rnd-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rnd-1.cfg
@@ -46,6 +46,7 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -93,8 +94,9 @@ PART
 	MODULE
 	{
 		name = ModuleB9PartSwitch
-    moduleID = endSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rnd-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-rnd-2.cfg
@@ -46,6 +46,7 @@ PART
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
 		SUBTYPE
 		{
 			name =  Solid
@@ -94,6 +95,8 @@ PART
 	{
 		name = ModuleB9PartSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+		moduleID = endSwitch
 		SUBTYPE
 		{
 			name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-sqr-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-sqr-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -116,6 +117,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-sqr-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-sqr-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -116,6 +117,8 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
+	moduleID = endSwitch
     SUBTYPE
     {
       name =  None

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-stp-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-stp-1.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/Bus/nfex-bus-stp-2.cfg
+++ b/GameData/NearFutureExploration/Parts/Bus/nfex-bus-stp-2.cfg
@@ -45,6 +45,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name =  Solid
@@ -93,6 +94,7 @@ PART
   {
     name = ModuleB9PartSwitch
     switcherDescription = #LOC_NFEX_Switcher_Endcap_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Endcap_Bus_Plural
     moduleID = endSwitch
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-1.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-1.cfg
@@ -39,6 +39,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 40
 		
 		SUBTYPE

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-2.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-2.cfg
@@ -39,6 +39,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume =  20
 		
 		SUBTYPE

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-3.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-3.cfg
@@ -39,6 +39,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 10
 		
 		SUBTYPE

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-tiny-1.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-tiny-1.cfg
@@ -39,6 +39,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 2.5
 		
 		SUBTYPE

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-1.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-1.cfg
@@ -41,6 +41,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 240
 		
 		SUBTYPE
@@ -133,6 +134,7 @@
     name = ModuleB9PartSwitch
     moduleID = structureSwitch
     switcherDescription = #LOC_NFEX_Switcher_Structure
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_StructurePlural
     
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-2.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-2.cfg
@@ -41,6 +41,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 120
 		
 		SUBTYPE
@@ -133,6 +134,7 @@
     name = ModuleB9PartSwitch
     moduleID = structureSwitch
     switcherDescription = #LOC_NFEX_Switcher_Structure
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_StructurePlural
     
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-3.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-3.cfg
@@ -41,6 +41,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
     baseVolume = 60
 		
 		SUBTYPE
@@ -133,6 +134,7 @@
     name = ModuleB9PartSwitch
     moduleID = structureSwitch
     switcherDescription = #LOC_NFEX_Switcher_Structure
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_StructurePlural
     
     SUBTYPE
     {

--- a/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-tiny-1.cfg
+++ b/GameData/NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-tiny-1.cfg
@@ -42,6 +42,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_FuelTank
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_FuelTankPlural
 		baseVolume = 10
 		SUBTYPE
 		{

--- a/GameData/NearFutureExploration/Parts/Ground/nfex-landing-leg-nano-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Ground/nfex-landing-leg-nano-1.cfg
@@ -176,6 +176,7 @@
 		name = ModuleB9PartSwitch
 		moduleID = surfaceSwitch
 		switcherDescription = #LOC_NFEX_Switcher_Suspension
+		switcherDescriptionPlural = #LOC_NFEX_Switcher_Suspension_Plural
 		SUBTYPE
 		{
 			name =  Suspension 

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-chfr-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-chfr-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-cyl-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-cyl-1.cfg
@@ -101,6 +101,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-dsk-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-dsk-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-plto-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-plto-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-rkt-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-rkt-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-rnd-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-rnd-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-sqr-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-sqr-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare

--- a/GameData/NearFutureExploration/Parts/Probe/nfex-probe-stp-1.cfg
+++ b/GameData/NearFutureExploration/Parts/Probe/nfex-probe-stp-1.cfg
@@ -100,6 +100,7 @@ PART
     name = ModuleB9PartSwitch
     moduleID = surfaceSwitch
     switcherDescription = #LOC_NFEX_Switcher_Surface_Bus
+	switcherDescriptionPlural = #LOC_NFEX_Switcher_Surface_Bus_Plural
     SUBTYPE
     {
       name = Bare


### PR DESCRIPTION
* plural descriptions for B9 modules (ignore typo. I fixed that)
* missing endcap moduleID keys in some parts

![preview](https://i.imgur.com/SAsHIVB.png)