### PR TITLE
Add RemoteTech support

### DIFF
--- a/GameData/NearFutureExploration/Patches/NFExplorationAntennaFeedsNFeX.cfg
+++ b/GameData/NearFutureExploration/Patches/NFExplorationAntennaFeedsNFeX.cfg
@@ -8,7 +8,7 @@
   }
 }
 
-@PART[nfex-antenna*]:FOR[NearFutureExploration]:NEEDS[RemoteTech|RealAntennas]
+@PART[nfex-antenna*]:FOR[NearFutureExploration]:NEEDS[RealAntennas]
 {
 
   !MODULE[ModuleAntennaFeed] {}


### PR DESCRIPTION
Hi, 
The support for RemoteTech is implemented, as shown below. The changes are to enable NFE to utilize ModuleRTAntenna in place of ModuleDataTransmitterFeedeable (should not run with RemoteTech installed).
![1](https://user-images.githubusercontent.com/22871614/80868897-d0f41f00-8ccf-11ea-9956-85a2ab045cf5.PNG)

I will add new configurations in RemoteTech repository for all the NFE antennas and reflectors.

Thank you.
